### PR TITLE
feat: Add ci-check target and test coverage reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for common dev tasks (make from repo root)
 
-.PHONY: help docker-up docker-down build backend-run migrations-up migrations-down backup-run test lint
+.PHONY: help docker-up docker-down build backend-run migrations-up migrations-down backup-run test lint test-coverage ci-check
 .PHONY: check-env psql redis-cli logs open-docs list-backups psql-runner
 
 help:
@@ -13,7 +13,9 @@ help:
 	@echo "  migrations-down  - rollback last migration (uses DB_DSN env)"
 	@echo "  backup-run       - run DB backup job"
 	@echo "  test             - run backend tests"
+	@echo "  test-coverage    - run backend tests and generate coverage report"
 	@echo "  lint             - run golangci-lint (backend)"
+	@echo "  ci-check         - run lint and test coverage"
 
 # Docker shortcuts
 docker-up:
@@ -74,6 +76,15 @@ test:
 	@echo "Running go tests"
 	cd apps/backend && go test ./...
 
+test-coverage:
+	@echo "Running go tests with coverage"
+	cd apps/backend && go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o coverage.html
+
 # Lint (requires golangci-lint installed locally)
 lint:
 	cd apps/backend && golangci-lint run ./...
+
+ci-check:
+	@echo "Running CI checks"
+	make lint
+	make test-coverage

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 
 # env file
 .env
+
+# test coverage reports
+coverage.html

--- a/apps/backend/internal/service/auth_test.go
+++ b/apps/backend/internal/service/auth_test.go
@@ -209,7 +209,7 @@ func TestSyncUserUpserts(t *testing.T) {
 	raw := []byte(`{"id":"user_123","external_id":"ext_123","first_name":"Alice"}`)
 
 	email := "alice@example.com"
-	err := authSvc.SyncUser(ctx, clerkID, externalID, email, firstName, lastName, imageURL, raw)
+	err := authSvc.SyncUser(ctx, clerkID, externalID, email, firstName, lastName, imageURL, "", raw)
 	require.NoError(t, err)
 
 	// Query DB for the user
@@ -244,7 +244,7 @@ func TestSyncUserUpserts_ClerkIDOnly(t *testing.T) {
 	imageURL := "https://example.com/bob.jpg"
 	raw := []byte(`{"id":"user_only_123","first_name":"Bob"}`)
 
-	err := authSvc.SyncUser(ctx, clerkID, externalID, email, firstName, lastName, imageURL, raw)
+	err := authSvc.SyncUser(ctx, clerkID, externalID, email, firstName, lastName, imageURL, "", raw)
 	require.NoError(t, err)
 
 	var gotClerkID string


### PR DESCRIPTION
This pull request adds new development workflow commands to the `Makefile` and updates the `.gitignore` to exclude test coverage reports. The main focus is on making it easier to run tests with coverage and to perform CI checks locally.

**Makefile improvements:**

* Added new `test-coverage` target to run backend tests and generate a coverage report (`coverage.html`).
* Added new `ci-check` target to run both linting and test coverage as a single command.
* Updated the `.PHONY` list and help text to include the new targets. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L3-R3) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R16-R18)

**.gitignore update:**

* Added `coverage.html` to `.gitignore` to prevent test coverage reports from being committed.